### PR TITLE
Updated NotificationBootstrap as Add-PSSnapin is no longer valid

### DIFF
--- a/DiscordNotificationBootstrap.ps1
+++ b/DiscordNotificationBootstrap.ps1
@@ -10,7 +10,7 @@ if($config.debug_log) {
 }
 
 # Add Veeam snap-in.
-Add-PSSnapin VeeamPSSnapin
+Import-Module Veeam.Backup.PowerShell
 
 # Get the Veeam job from parent process.
 $parentpid = (Get-WmiObject Win32_Process -Filter "processid='$pid'").parentprocessid.ToString()


### PR DESCRIPTION
As per latest Veeam Backup & Replication update, Add-PSSnapin is no longer valid. 

https://www.veeam.com/veeam_backup_11_0_whats_new_wn.pdf
https://forums.veeam.com/powershell-f26/veeam-11-powershell-snapin-gone-t72598.html